### PR TITLE
feat: add comprehensive type annotations for YAML-driven types

### DIFF
--- a/src/memg_core/api/public.py
+++ b/src/memg_core/api/public.py
@@ -56,11 +56,11 @@ class MemgServices:
         self.db_clients = DatabaseClients(yaml_path=yaml_path)
         self.db_clients.init_dbs(db_path=db_path, db_name=db_name)
 
-        # Create services
-        self.memory_service = create_memory_service(self.db_clients)
-        self.search_service = create_search_service(self.db_clients)
-        self.yaml_translator = YamlTranslator(yaml_path=yaml_path)
-        self.hrid_tracker = HridTracker(self.db_clients.get_kuzu_interface())
+        # Create services with proper typing
+        self.memory_service: MemoryService | None = create_memory_service(self.db_clients)
+        self.search_service: SearchService | None = create_search_service(self.db_clients)
+        self.yaml_translator: YamlTranslator | None = YamlTranslator(yaml_path=yaml_path)
+        self.hrid_tracker: HridTracker | None = HridTracker(self.db_clients.get_kuzu_interface())
 
     def close(self):
         """Close database connections and cleanup resources."""

--- a/src/memg_core/core/types.py
+++ b/src/memg_core/core/types.py
@@ -23,7 +23,7 @@ class TypeRegistry:
     _instance: Optional["TypeRegistry"] = None
     _initialized: bool = False
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._entity_types: type[Enum] | None = None
         self._relation_predicates: type[Enum] | None = None
         self._pydantic_models: dict[str, type[BaseModel]] = {}
@@ -71,7 +71,7 @@ class TypeRegistry:
         cls._initialized = True
         return instance
 
-    def _build_entity_types(self):
+    def _build_entity_types(self) -> None:
         """Build EntityType enum dynamically from YAML entities."""
         if self._yaml_schema is None:
             raise RuntimeError("YAML schema not loaded")
@@ -94,10 +94,10 @@ class TypeRegistry:
         if not entity_names:
             raise ValueError("No valid entity names found in YAML")
 
-        # Create dynamic enum
-        self._entity_types = Enum("EntityType", entity_names)
+        # Create dynamic enum - use type ignore for mypy since this is runtime dynamic
+        self._entity_types = Enum("EntityType", entity_names)  # type: ignore[misc]
 
-    def _build_relation_predicates(self):
+    def _build_relation_predicates(self) -> None:
         """Build RelationPredicate enum dynamically from YAML relations."""
         if self._yaml_schema is None:
             raise RuntimeError("YAML schema not loaded")
@@ -135,11 +135,11 @@ class TypeRegistry:
                 "No defaults allowed."
             )
 
-        # Create dynamic enum
+        # Create dynamic enum - use type ignore for mypy since this is runtime dynamic
         predicate_items = [(p, p) for p in sorted(predicates)]
-        self._relation_predicates = Enum("RelationPredicate", predicate_items)
+        self._relation_predicates = Enum("RelationPredicate", predicate_items)  # type: ignore[misc]
 
-    def _build_pydantic_models(self):
+    def _build_pydantic_models(self) -> None:
         """Build Pydantic models dynamically from YAML entities with inheritance support."""
         if self._yaml_schema is None:
             raise RuntimeError("YAML schema not loaded")


### PR DESCRIPTION
- Add return type annotations to all TypeRegistry methods
- Use type: ignore for dynamic Enum creation (runtime YAML-driven)
- Add Optional type annotations for MemgServices attributes
- Enable proper mypy checking with --check-untyped-defs

Dynamic types project from YAML schema to rest of codebase:
- TypeRegistry builds Enums and Pydantic models from YAML at runtime
- Type hints preserve YAML-first architecture while satisfying mypy
- No bulky defensive code - clean type annotations only

All mypy errors resolved, functionality verified.