### PR TITLE
V075

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,20 @@ defaults:
   datetime_format: "%Y-%m-%d %H:%M:%S"  # Applied to all datetime fields
 ```
 
+**Supported Field Types**: Rich type system
+```yaml
+- name: product
+  fields:
+    name: { type: string }          # Text
+    price: { type: float }           # Decimal numbers
+    quantity: { type: int }          # Integers (also: integer)
+    in_stock: { type: bool }         # Booleans (also: boolean)
+    created_at: { type: datetime }   # Timestamps
+    tags: { type: list }             # Lists
+    category: { type: enum, choices: [A, B, C] }  # Enumerations
+    embedding: { type: vector }      # Embedding vectors
+```
+
 ## Embedding Configuration
 
 ### Default: FastEmbed (Offline, No API Keys)

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ defaults:
 ```yaml
 - name: product
   fields:
-    name: { type: string }          # Text
+    name: { type: string, required: true }  # Text (required)
     price: { type: float }           # Decimal numbers
     quantity: { type: int }          # Integers (also: integer)
     in_stock: { type: bool }         # Booleans (also: boolean)
@@ -195,6 +195,17 @@ defaults:
     category: { type: enum, choices: [A, B, C] }  # Enumerations
     embedding: { type: vector }      # Embedding vectors
 ```
+
+**Currently Enforced Constraints:**
+- ✅ `required: true` - Field must be present
+- ✅ `type: <type>` - Type must match (string, int, float, bool, datetime, list, enum, vector)
+- ✅ `enum` with `choices: [...]` - Value must be one of the specified choices
+- ✅ `system: true` - System fields (id, user_id, timestamps) handled automatically
+
+**Not Yet Implemented** (tracked in [#issue]):
+- ⚠️ `default: value` - Defaults are not auto-applied (fields absent if not provided)
+- ⚠️ `max_length: N` - String length validation not enforced
+- ⚠️ Other Pydantic-style constraints (min_value, pattern, etc.)
 
 ## Embedding Configuration
 

--- a/config/core.test.yaml
+++ b/config/core.test.yaml
@@ -57,6 +57,9 @@ entities:
       status: { type: enum, choices: [backlog, todo, in_progress, in_review, done, cancelled], default: backlog }
       priority: { type: enum, choices: [low, medium, high, critical], default: medium }
       due_date: { type: datetime }
+      estimated_hours: { type: float }  # Numeric type: estimated hours to complete
+      story_points: { type: int }  # Numeric type: story points for task
+      completed: { type: bool, default: false }  # Numeric type: completion flag
     override:
       display_field: details  # Display uses details instead of statement
     relations:

--- a/config/core.test.yaml
+++ b/config/core.test.yaml
@@ -59,7 +59,7 @@ entities:
       due_date: { type: datetime }
       estimated_hours: { type: float }  # Numeric type: estimated hours to complete
       story_points: { type: int }  # Numeric type: story points for task
-      completed: { type: bool, default: false }  # Numeric type: completion flag
+      completed: { type: bool }  # Numeric type: completion flag
     override:
       display_field: details  # Display uses details instead of statement
     relations:

--- a/src/memg_core/__init__.py
+++ b/src/memg_core/__init__.py
@@ -3,10 +3,6 @@
 # Re-export only the stable public API
 from .api.public import MemgClient, add_memory, search
 from .core.interfaces.embedder_protocol import EmbedderProtocol
-
-try:
-    from .version import __version__
-except ModuleNotFoundError:  # pragma: no cover - best effort for local dev
-    __version__ = "0.0.0"
+from .version import __version__
 
 __all__ = ["MemgClient", "EmbedderProtocol", "add_memory", "search", "__version__"]

--- a/src/memg_core/__init__.py
+++ b/src/memg_core/__init__.py
@@ -1,7 +1,12 @@
 """memg-core: True memory for AI - minimal public API"""
 
 # Re-export only the stable public API
-from .api.public import add_memory, search
-from .version import __version__
+from .api.public import MemgClient, add_memory, search
+from .core.interfaces.embedder_protocol import EmbedderProtocol
 
-__all__ = ["add_memory", "search", "__version__"]
+try:
+    from .version import __version__
+except ModuleNotFoundError:  # pragma: no cover - best effort for local dev
+    __version__ = "0.0.0"
+
+__all__ = ["MemgClient", "EmbedderProtocol", "add_memory", "search", "__version__"]

--- a/src/memg_core/api/public.py
+++ b/src/memg_core/api/public.py
@@ -10,6 +10,7 @@ import os
 from typing import Any
 
 from ..core.config import get_config
+from ..core.interfaces.embedder_protocol import EmbedderProtocol
 from ..core.models import SearchResult
 from ..core.pipelines.indexer import MemoryService, create_memory_service
 from ..core.pipelines.retrieval import SearchService, create_search_service
@@ -23,14 +24,17 @@ class MemgClient:
     Provides a clean interface for memory operations with explicit resource management.
     """
 
-    def __init__(self, yaml_path: str, db_path: str):
+    def __init__(self, yaml_path: str, db_path: str, embedder: EmbedderProtocol | None = None):
         """Initialize client for long-running server usage.
 
         Args:
             yaml_path: Path to YAML schema configuration file.
             db_path: Base directory path for database storage.
+            embedder: Optional custom embedder. If provided, will be used instead
+                of the default FastEmbed-based embedder. Must implement EmbedderProtocol
+                (get_embedding and get_embeddings methods).
         """
-        self._db_clients = DatabaseClients(yaml_path=yaml_path)
+        self._db_clients = DatabaseClients(yaml_path=yaml_path, embedder=embedder)
         config = get_config()
         self._db_clients.init_dbs(db_path=db_path, db_name=config.memg.qdrant_collection_name)
 

--- a/src/memg_core/core/interfaces/__init__.py
+++ b/src/memg_core/core/interfaces/__init__.py
@@ -1,7 +1,8 @@
 """Interfaces module - storage adapters."""
 
 from .embedder import Embedder
+from .embedder_protocol import EmbedderProtocol
 from .kuzu import KuzuInterface
 from .qdrant import QdrantInterface
 
-__all__ = ["Embedder", "KuzuInterface", "QdrantInterface"]
+__all__ = ["Embedder", "EmbedderProtocol", "KuzuInterface", "QdrantInterface"]

--- a/src/memg_core/core/interfaces/embedder_protocol.py
+++ b/src/memg_core/core/interfaces/embedder_protocol.py
@@ -1,0 +1,53 @@
+"""Embedder protocol for flexible embedding implementations.
+
+This protocol defines the interface that any embedder must implement.
+Consumers can provide their own implementations as long as they satisfy this protocol.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class EmbedderProtocol(Protocol):
+    """Protocol defining the embedder interface (structural typing - duck typing with type hints).
+
+    This is NOT an abstract base class - you don't need to inherit from it.
+    Any object with get_embedding() and get_embeddings() methods will work.
+    The Protocol is purely for type checkers (mypy, pyright) and IDE support.
+
+    This allows consumers to provide their own embedding implementations
+    (OpenAI, Cohere, custom models, etc.) without modifying memg-core code.
+
+    Example:
+        >>> class MyEmbedder:  # No inheritance needed!
+        ...     def get_embedding(self, text: str) -> list[float]:
+        ...         return [0.1, 0.2, 0.3]  # Your implementation
+        ...     def get_embeddings(self, texts: list[str]) -> list[list[float]]:
+        ...         return [[0.1, 0.2, 0.3] for _ in texts]
+        >>>
+        >>> from memg_core.api import MemgClient
+        >>> client = MemgClient(yaml_path="...", db_path="...", embedder=MyEmbedder())
+    """
+
+    def get_embedding(self, text: str) -> list[float]:
+        """Generate embedding vector for a single text.
+
+        Args:
+            text: Input text to embed.
+
+        Returns:
+            Embedding vector as list of floats.
+        """
+        ...
+
+    def get_embeddings(self, texts: list[str]) -> list[list[float]]:
+        """Generate embedding vectors for multiple texts.
+
+        Args:
+            texts: List of input texts to embed.
+
+        Returns:
+            List of embedding vectors.
+        """
+        ...

--- a/src/memg_core/core/types.py
+++ b/src/memg_core/core/types.py
@@ -311,6 +311,12 @@ class TypeRegistry:
 
         if yaml_type == "string":
             return str
+        if yaml_type in ("int", "integer"):
+            return int
+        if yaml_type in ("float", "number"):
+            return float
+        if yaml_type in ("bool", "boolean"):
+            return bool
         if yaml_type == "datetime":
             return datetime
         if yaml_type == "list":

--- a/src/memg_core/core/types.py
+++ b/src/memg_core/core/types.py
@@ -309,25 +309,30 @@ class TypeRegistry:
         """Convert YAML type to Python type - crash on unknown types."""
         yaml_type = yaml_type.lower()
 
-        if yaml_type == "string":
-            return str
-        if yaml_type in ("int", "integer"):
-            return int
-        if yaml_type in ("float", "number"):
-            return float
-        if yaml_type in ("bool", "boolean"):
-            return bool
-        if yaml_type == "datetime":
-            return datetime
-        if yaml_type == "list":
-            return list
+        # Type mapping with aliases
+        type_map = {
+            "string": str,
+            "int": int,
+            "integer": int,
+            "float": float,
+            "number": float,
+            "bool": bool,
+            "boolean": bool,
+            "datetime": datetime,
+            "list": list,
+            "vector": list[float],
+        }
+
+        # Check simple type mappings first
+        if yaml_type in type_map:
+            return type_map[yaml_type]
+
+        # Handle enum separately (requires additional validation)
         if yaml_type == "enum":
             choices = field_def.get("choices")
             if not choices:
                 raise ValueError(f"Enum field missing 'choices': {field_def}")
             return Literal[tuple(choices)]
-        if yaml_type == "vector":
-            return list[float]
 
         raise ValueError(f"Unknown YAML type: {yaml_type}")
 

--- a/tests/test_custom_embedder.py
+++ b/tests/test_custom_embedder.py
@@ -1,0 +1,195 @@
+"""Tests for custom embedder functionality.
+
+Validates that consumers can provide their own embedder implementations
+and that they are used correctly throughout the memory lifecycle.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+
+from memg_core import MemgClient
+from memg_core.utils.db_clients import DatabaseClients
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# Override the global mock_embedder fixture for these tests
+@pytest.fixture(autouse=True)
+def mock_embedder():
+    """Override global fixture - don't mock the embedder in these tests."""
+    # Just yield without any mocking - we want to test real embedder behavior
+    yield None
+
+
+class MockEmbedder:
+    """Simple mock embedder for testing."""
+
+    def __init__(self, dimension: int = 384):
+        """Initialize with a specific embedding dimension."""
+        self.dimension = dimension
+        self.call_count = 0
+        self.call_history: list[str] = []
+
+    def get_embedding(self, text: str) -> list[float]:
+        """Return a deterministic embedding based on text length."""
+        self.call_count += 1
+        self.call_history.append(text)
+        # Create a simple embedding: text length repeated to match dimension
+        base = float(len(text))
+        return [base] * self.dimension
+
+    def get_embeddings(self, texts: list[str]) -> list[list[float]]:
+        """Return embeddings for multiple texts."""
+        return [self.get_embedding(text) for text in texts]
+
+
+def test_mock_embedder_implements_protocol():
+    """MockEmbedder should have the required methods for the protocol."""
+    embedder = MockEmbedder()
+    # Protocol is for type checking, not runtime - verify methods exist
+    assert hasattr(embedder, "get_embedding")
+    assert hasattr(embedder, "get_embeddings")
+    assert callable(embedder.get_embedding)
+    assert callable(embedder.get_embeddings)
+
+
+def test_database_clients_accepts_custom_embedder():
+    """DatabaseClients should accept and use custom embedder."""
+    mock = MockEmbedder()
+    clients = DatabaseClients(embedder=mock)
+
+    # Should return the provided embedder
+    embedder = clients.get_embedder()
+    assert embedder is mock
+
+    # Verify it works
+    result = embedder.get_embedding("test")
+    assert result == [4.0] * 384  # "test" has 4 chars
+    assert mock.call_count == 1
+
+
+def test_database_clients_uses_default_when_no_embedder_provided():
+    """DatabaseClients should create default embedder when none provided."""
+    clients = DatabaseClients()
+
+    # First call creates the embedder
+    embedder1 = clients.get_embedder()
+    assert embedder1 is not None
+
+    # Second call returns the same instance (singleton within client)
+    embedder2 = clients.get_embedder()
+    assert embedder2 is embedder1
+
+
+def test_memg_client_with_custom_embedder(tmp_path: Path):
+    """MemgClient should accept and use custom embedder through full memory lifecycle."""
+    # Setup
+    yaml_path = os.environ.get("MEMG_YAML_PATH", "config/core.test.yaml")
+    db_path = str(tmp_path / "custom_embedder_test")
+
+    mock = MockEmbedder()
+    client = MemgClient(yaml_path=yaml_path, db_path=db_path, embedder=mock)
+
+    # Add a memory - should trigger embedding
+    hrid = client.add_memory(
+        memory_type="note",
+        payload={"statement": "Testing custom embedder", "project": "test"},
+        user_id="test_user",
+    )
+
+    # Verify embedder was called with the anchor text
+    assert mock.call_count == 1
+    assert "Testing custom embedder" in mock.call_history[0]
+
+    # Search should also use custom embedder
+    results = client.search(query="custom embedder", user_id="test_user", limit=5)
+
+    # Another embedding call for the search query
+    assert mock.call_count == 2
+    assert "custom embedder" in mock.call_history[1]
+
+    # Should find our memory
+    assert len(results.memories) > 0
+    found = any(m.hrid == hrid for m in results.memories)
+    assert found
+
+    client.close()
+
+
+def test_memg_client_without_custom_embedder_uses_default(tmp_path: Path):
+    """MemgClient without embedder should use default FastEmbed implementation."""
+    yaml_path = os.environ.get("MEMG_YAML_PATH", "config/core.test.yaml")
+    db_path = str(tmp_path / "default_embedder_test")
+
+    # No custom embedder provided
+    client = MemgClient(yaml_path=yaml_path, db_path=db_path)
+
+    # Should still work with default embedder
+    hrid = client.add_memory(
+        memory_type="note",
+        payload={"statement": "Testing default embedder", "project": "test"},
+        user_id="test_user",
+    )
+
+    assert hrid is not None
+    assert hrid.startswith("NOTE_")
+
+    # Search should work
+    results = client.search(query="default embedder", user_id="test_user", limit=5)
+    assert len(results.memories) > 0
+
+    client.close()
+
+
+def test_custom_embedder_with_different_dimension():
+    """Custom embedders can use different dimensions."""
+    # Create embedder with different dimension
+    mock = MockEmbedder(dimension=128)
+    clients = DatabaseClients(embedder=mock)
+
+    embedder = clients.get_embedder()
+    result = embedder.get_embedding("hello")
+
+    assert len(result) == 128
+    assert all(x == 5.0 for x in result)  # "hello" has 5 chars
+
+
+def test_embedder_protocol_duck_typing():
+    """Any object with get_embedding/get_embeddings methods should work."""
+
+    class MinimalEmbedder:
+        """Minimal embedder without inheriting anything."""
+
+        def get_embedding(self, text: str) -> list[float]:
+            return [1.0, 2.0, 3.0]
+
+        def get_embeddings(self, texts: list[str]) -> list[list[float]]:
+            return [[1.0, 2.0, 3.0] for _ in texts]
+
+    minimal = MinimalEmbedder()
+    # Verify it has the protocol methods (duck typing)
+    assert hasattr(minimal, "get_embedding") and callable(minimal.get_embedding)
+    assert hasattr(minimal, "get_embeddings") and callable(minimal.get_embeddings)
+
+    clients = DatabaseClients(embedder=minimal)
+    embedder = clients.get_embedder()
+    assert embedder.get_embedding("test") == [1.0, 2.0, 3.0]
+
+
+def test_embedder_batch_processing():
+    """Custom embedder should handle batch processing correctly."""
+    mock = MockEmbedder(dimension=10)
+
+    texts = ["first", "second", "third"]
+    results = mock.get_embeddings(texts)
+
+    assert len(results) == 3
+    assert results[0] == [5.0] * 10  # "first" = 5 chars
+    assert results[1] == [6.0] * 10  # "second" = 6 chars
+    assert results[2] == [5.0] * 10  # "third" = 5 chars
+    assert mock.call_count == 3  # get_embeddings calls get_embedding internally

--- a/tests/unit/test_numeric_types.py
+++ b/tests/unit/test_numeric_types.py
@@ -82,10 +82,10 @@ def test_optional_numeric_fields():
     result = get_memory(hrid=hrid, user_id="test_user")
     memory = result.memories[0]
 
-    # Optional numeric fields not required (may be absent or None)
-    assert "estimated_hours" not in memory.payload or memory.payload["estimated_hours"] is None
-    assert "story_points" not in memory.payload or memory.payload["story_points"] is None
-    # completed field may not be in payload if not provided (default doesn't auto-populate)
-    assert "completed" not in memory.payload or memory.payload["completed"] is False
+    # Optional numeric fields should be absent when not provided
+    # Note: memg-core doesn't auto-populate defaults from YAML schema
+    assert "estimated_hours" not in memory.payload
+    assert "story_points" not in memory.payload
+    assert "completed" not in memory.payload
 
     delete_memory(hrid=hrid, user_id="test_user")

--- a/tests/unit/test_numeric_types.py
+++ b/tests/unit/test_numeric_types.py
@@ -1,0 +1,91 @@
+"""Quick validation tests for numeric type support (int, float, bool)."""
+
+from __future__ import annotations
+
+from memg_core.api.public import add_memory, delete_memory, get_memory
+
+
+def test_numeric_types_in_task():
+    """Test that float, int, and bool types work in task entity."""
+    # Add task with all numeric types
+    hrid = add_memory(
+        memory_type="task",
+        payload={
+            "statement": "Implement numeric type support",
+            "details": "Add int, float, bool to type system",
+            "project": "memg-core",
+            "estimated_hours": 2.5,  # float
+            "story_points": 3,  # int
+            "completed": False,  # bool
+        },
+        user_id="test_user",
+    )
+
+    assert hrid.startswith("TASK_")
+
+    # Retrieve and verify types
+    result = get_memory(hrid=hrid, user_id="test_user")
+    assert result is not None
+    memory = result.memories[0]
+
+    assert memory.payload["estimated_hours"] == 2.5
+    assert isinstance(memory.payload["estimated_hours"], float)
+
+    assert memory.payload["story_points"] == 3
+    assert isinstance(memory.payload["story_points"], int)
+
+    assert memory.payload["completed"] is False
+    assert isinstance(memory.payload["completed"], bool)
+
+    # Cleanup
+    delete_memory(hrid=hrid, user_id="test_user")
+
+
+def test_numeric_type_aliases():
+    """Test that type aliases (integer, number, boolean) work."""
+    # This validates the aliases in _get_python_type work correctly
+    # If the YAML used "integer", "number", "boolean" they would work too
+    hrid = add_memory(
+        memory_type="task",
+        payload={
+            "statement": "Test type aliases",
+            "estimated_hours": 1.0,
+            "story_points": 1,
+            "completed": True,
+        },
+        user_id="test_user",
+    )
+
+    result = get_memory(hrid=hrid, user_id="test_user")
+    memory = result.memories[0]
+
+    # All types preserved
+    assert isinstance(memory.payload["estimated_hours"], float)
+    assert isinstance(memory.payload["story_points"], int)
+    assert isinstance(memory.payload["completed"], bool)
+
+    delete_memory(hrid=hrid, user_id="test_user")
+
+
+def test_optional_numeric_fields():
+    """Numeric fields should be optional if not required."""
+    # Create task without optional numeric fields
+    hrid = add_memory(
+        memory_type="task",
+        payload={
+            "statement": "Minimal task",
+            "details": "Only required fields",
+        },
+        user_id="test_user",
+    )
+
+    result = get_memory(hrid=hrid, user_id="test_user")
+    memory = result.memories[0]
+
+    # Optional numeric fields not required (may be absent or None)
+    assert "estimated_hours" not in memory.payload or memory.payload["estimated_hours"] is None
+    assert "story_points" not in memory.payload or memory.payload["story_points"] is None
+    # completed field may not be in payload if not provided (default doesn't auto-populate)
+    assert "completed" not in memory.payload or memory.payload["completed"] is False
+
+    delete_memory(hrid=hrid, user_id="test_user")


### PR DESCRIPTION
  -  Added mote type support (numerical)
  - Made embedding model override - through the public interface - easier and more standard, yet testable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce numeric type support (int/float/bool + aliases) and a pluggable EmbedderProtocol with MemgClient/DatabaseClients injection; update docs and tests accordingly.
> 
> - **Core/API**:
>   - Add `EmbedderProtocol` and export via `memg_core` and `core.interfaces`.
>   - `MemgClient` accepts optional `embedder` implementing `EmbedderProtocol` and wires through `DatabaseClients`.
>   - `DatabaseClients` accepts/stores custom embedder and returns it from `get_embedder()` (defaults to FastEmbed-backed `Embedder`).
> - **Type System**:
>   - Extend YAML type mapping to support `int`/`integer`, `float`/`number`, `bool`/`boolean`, and `vector` aliasing; keep `enum` handling.
> - **Config/Test Schema**:
>   - Update `config/core.test.yaml` `task` entity: add `estimated_hours: float`, `story_points: int`, `completed: bool`.
> - **Docs**:
>   - Document supported field types and current/unsupported constraints.
>   - Expand embedding section with default FastEmbed and custom embedder usage example and protocol description.
> - **Tests**:
>   - Add `tests/test_custom_embedder.py` covering protocol conformance, injection, default behavior, dimension handling, and batch processing.
>   - Add `tests/unit/test_numeric_types.py` validating numeric types and aliases in payloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b82e58e2b58fee4b9e4ae96010e5db74e097b2bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->