### PR TITLE
Upgrade to v075

### DIFF
--- a/experiments/mcp/requirements_mcp.txt
+++ b/experiments/mcp/requirements_mcp.txt
@@ -4,4 +4,4 @@ fastapi>=0.115.0
 uvicorn>=0.35.0
 pydantic>=2.11.7
 starlette>=0.47.2
-memg_core==0.7.4
+memg_core==0.7.5


### PR DESCRIPTION
MCP lib version upgrade

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `memg_core` from 0.7.4 to 0.7.5 in `experiments/mcp/requirements_mcp.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9809710b88e9e73279063ee0161e0369edc94c4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->